### PR TITLE
fix HPO inclusion in HCAO

### DIFF
--- a/ols/ols-config.yaml
+++ b/ols/ols-config.yaml
@@ -75,7 +75,7 @@ ontologies:
       - http://purl.obolibrary.org/obo/HP_
     reasoner: None
     oboSlims: false
-    ontology_purl: file:///opt/ols/ontologies/hp_slim.owl
+    ontology_purl: file:///opt/ols/ontologies/hpo_slim.owl
 
 
 


### PR DESCRIPTION
fix a mis-configuration in 1.0.38 where `ols-config.yml` references `hp_slim.owl` the generated file is called `hpo_slim.owl`.

see ebi-ait/hca-ebi-dev-team#490

I am not sure how I can add a unit test for this.